### PR TITLE
Added command line argument to print version

### DIFF
--- a/SemiBin/main.py
+++ b/SemiBin/main.py
@@ -25,6 +25,8 @@ def parse_args(args):
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                      description='Semi-supervised siamese neural network for metagenomic binning')
 
+    parser.version = ver
+
     parser.add_argument('-v',
                         '--version',
                         action='version',

--- a/SemiBin/main.py
+++ b/SemiBin/main.py
@@ -19,10 +19,16 @@ from .cluster import cluster
 import shutil
 import numpy as np
 import random
+from .semibin_version import __version__ as ver
 
 def parse_args(args):
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                      description='Semi-supervised siamese neural network for metagenomic binning')
+
+    parser.add_argument('-v',
+                        '--version',
+                        action='version',
+                        help='Print the version number')
 
     subparsers = parser.add_subparsers(title='SemiBin subcommands',
                                        dest='cmd',


### PR DESCRIPTION
I had a go to fix #13 

I added a parser argument `-v` (`--version`) to allow printing the application version.

After testing on my computer by running `SemiBin -v` and `SemiBin --version`, the below is the output before the change,
```
$ SemiBin -v
usage: SemiBin [-h]  ...
SemiBin: error: unrecognized arguments: -v
$ SemiBin --version
usage: SemiBin [-h]  ...
SemiBin: error: unrecognized arguments: --version
```
and the below is the output after the change.
```
$ SemiBin -v
0.1.1
$ SemiBin --version
0.1.1
```