### PR TITLE
No bedtools tempfile

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,8 @@ Unreleased
 	* Lower memory usage and faster speed for `bin` subcommand
 	* Reclustering is now the default (due to improved speed). Added
 	`--no-recluster` option to disable it
+	* Output of bedtools is now processed as a stream instead of using a
+	(potentially large) intermediate file
 
 Version 0.4.0 Tue Oct 10 2021 by BigDataBiology
 	* Add support for .xz FASTA files as inputs

--- a/test/test_cov.py
+++ b/test/test_cov.py
@@ -1,36 +1,35 @@
 from SemiBin.generate_coverage import calculate_coverage
-from os import path
-import pytest
 import pandas as pd
 from pandas.testing import assert_frame_equal
 
 
-def test_cov(tmpdir):
-    depth_file = path.join(tmpdir, 'depth.txt')
+def test_cov():
 
-    with open(depth_file, 'wt') as out_depth:
-        out_depth.write('k141_63080\t0\t6\t1\n')
-        out_depth.write('k141_63080\t6\t30\t2\n')
-        out_depth.write('k141_63080\t30\t138\t3\n')
-        out_depth.write('k141_63080\t138\t144\t2\n')
-        out_depth.write('k141_63080\t144\t174\t1\n')
-        out_depth.write('k141_63080\t174\t177\t2\n')
-        out_depth.write('k141_63080\t177\t257\t3\n')
-        out_depth.write('k141_63080\t257\t304\t2\n')
-        out_depth.write('k141_63080\t304\t315\t1\n')
-        out_depth.write('k141_0\t0\t45\t1\n')
-        out_depth.write('k141_0\t45\t88\t2\n')
-        out_depth.write('k141_0\t88\t138\t3\n')
-        out_depth.write('k141_0\t138\t159\t2\n')
-        out_depth.write('k141_0\t159\t183\t3\n')
-        out_depth.write('k141_0\t183\t225\t2\n')
-        out_depth.write('k141_0\t225\t227\t1\n')
-        out_depth.write('k141_0\t227\t297\t3\n')
-        out_depth.write('k141_0\t297\t338\t2\n')
-        out_depth.write('k141_0\t338\t365\t1\n')
+    test_data = [
+        'k141_63080\t0\t6\t1\n',
+        'k141_63080\t6\t30\t2\n',
+        'k141_63080\t30\t138\t3\n',
+        'k141_63080\t138\t144\t2\n',
+        'k141_63080\t144\t174\t1\n',
+        'k141_63080\t174\t177\t2\n',
+        'k141_63080\t177\t257\t3\n',
+        'k141_63080\t257\t304\t2\n',
+        'k141_63080\t304\t315\t1\n',
+        'k141_0\t0\t45\t1\n',
+        'k141_0\t45\t88\t2\n',
+        'k141_0\t88\t138\t3\n',
+        'k141_0\t138\t159\t2\n',
+        'k141_0\t159\t183\t3\n',
+        'k141_0\t183\t225\t2\n',
+        'k141_0\t225\t227\t1\n',
+        'k141_0\t227\t297\t3\n',
+        'k141_0\t297\t338\t2\n',
+        'k141_0\t338\t365\t1\n',
+    ]
 
     cov, cov_split = calculate_coverage(
-        depth_file,
+        test_data,
+        'test_data',
         must_link_threshold=0,
         is_combined=True,
         contig_threshold=0)
@@ -42,7 +41,8 @@ def test_cov(tmpdir):
                        'k141_63080_1', 'k141_63080_2', 'k141_0_1', 'k141_0_2'], columns=['cov']))
 
     cov = calculate_coverage(
-        depth_file,
+        test_data,
+        'test_data',
         must_link_threshold=0,
         is_combined=False,
         contig_threshold=0)


### PR DESCRIPTION
Process the output of bedtools directly, without using a temporary file.